### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -4660,6 +4660,10 @@ d-references {
   <h2>Table of contents</h2>
   <ul>`;
 
+    ToC += "</ul></nav>";
+    element.innerHTML = ToC;
+
+    const tocList = element.querySelector("ul");
     for (const el of headings) {
       // should element be included in TOC?
       const isInTitle = el.parentElement.tagName == "D-TITLE";
@@ -4669,17 +4673,21 @@ d-references {
       const title = el.textContent;
       const link = "#" + el.getAttribute("id");
 
-      let newLine = "<li>" + '<a href="' + link + '">' + title + "</a>" + "</li>";
-      if (el.tagName == "H3") {
-        newLine = "<ul>" + newLine + "</ul>";
-      } else {
-        newLine += "<br>";
-      }
-      ToC += newLine;
-    }
+      const li = document.createElement("li");
+      const a = document.createElement("a");
+      a.setAttribute("href", link);
+      a.textContent = title;
+      li.appendChild(a);
 
-    ToC += "</ul></nav>";
-    element.innerHTML = ToC;
+      if (el.tagName == "H3") {
+        const nested = document.createElement("ul");
+        nested.appendChild(li);
+        tocList.appendChild(nested);
+      } else {
+        tocList.appendChild(li);
+        tocList.appendChild(document.createElement("br"));
+      }
+    }
   }
 
   // Copyright 2018 The Distill Template Authors


### PR DESCRIPTION
Potential fix for [https://github.com/Ariel0503/Ariel0503.github.io/security/code-scanning/18](https://github.com/Ariel0503/Ariel0503.github.io/security/code-scanning/18)

Best fix: stop building ToC entries by concatenating untrusted text into HTML strings. Instead, build DOM nodes (`document.createElement`) and assign heading text via `textContent`, and links via `setAttribute`. Keep only the static wrapper HTML in `innerHTML` (or create it as nodes too), then append generated list items as DOM elements.

In `assets/js/distillpub/template.v2.js`, update the ToC construction region around lines 4663–4682:
- Remove `newLine` string concatenation with `title`.
- Create `<li>`, `<a>`, and optional nested `<ul>` nodes programmatically.
- Append these nodes to the existing `<ul>` inside `element`.
- Keep behavior for `H3` nesting and `<br>` for non-`H3` to preserve existing functionality.
- Remove final `ToC += "</ul></nav>"; element.innerHTML = ToC;` and instead close only static template where needed, then append nodes.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
