### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3330,7 +3330,7 @@ d-citation-list .references .title {
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {
         pattern:
-          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[\s\S]*?\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
         lookbehind: true,
         greedy: true,
       },


### PR DESCRIPTION
Potential fix for [https://github.com/Ariel0503/Ariel0503.github.io/security/code-scanning/4](https://github.com/Ariel0503/Ariel0503.github.io/security/code-scanning/4)

Best fix: replace the comment-matching fragment `\/\*[\s\S]*?\*\/` with a linear-time, delimiter-safe block-comment pattern that avoids ambiguous “any char” repetition.

In `assets/js/distillpub/template.v2.js` at the regex on line 3333, change:

- from: `\/\*[\s\S]*?\*\/`
- to: `\/\*(?:[^*]|\*(?!\/))*\*\/`

Why this works:
- It still matches `/* ... */` comments.
- It avoids the broad lazy `[\s\S]*?` that causes heavy backtracking.
- The repeated unit is constrained (`[^*]` or `*(not followed by /)`), so scanning to the closing `*/` is effectively linear and preserves existing behavior.

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
